### PR TITLE
feat: Añadir archivo mustangs.ts con datos de modelos clásicos

### DIFF
--- a/src/data/mustangs.ts
+++ b/src/data/mustangs.ts
@@ -1,0 +1,39 @@
+export interface Mustang {
+    id: number;
+    nombre: string;
+    año: number;
+    hp: number;
+    velocidad: number;
+    imgFront: string;
+    imgBack: string;
+}
+
+export const mustangs: Mustang[] = [
+    {
+        id: 1,
+        nombre: 'Mustang Fastback',
+        año: 1967,
+        hp: 271,
+        velocidad: 120,
+        imgFront: '/assets/fastback-front.jpg',
+        imgBack: '/assets/fastback-back.jpg',
+    },
+    {
+        id: 2,
+        nombre: 'Mustang Mach 1',
+        año: 1969,
+        hp: 335,
+        velocidad: 126,
+        imgFront: '/assets/mach1-front.jpg',
+        imgBack: '/assets/mach1-back.jpg',
+    },
+    {
+        id: 3,
+        nombre: 'Mustang Boss 302',
+        año: 1970,
+        hp: 290,
+        velocidad: 127,
+        imgFront: '/assets/boss302-front.jpg',
+        imgBack: '/assets/boss302-back.jpg',
+    }
+];


### PR DESCRIPTION
Este PR agrega el archivo `mustangs.ts` en la carpeta `src/data/`, que contiene una lista de modelos clásicos de Mustang (Fastback, Mach 1, Boss 302), incluyendo su nombre, año, potencia, velocidad máxima e imágenes simuladas.

Este archivo se usará en futuros componentes como `CarDetailView` y `GalleryView` para mostrar los modelos en la app.

-  Estructura de tipo Mustang

-  Datos básicos listos para visualización
